### PR TITLE
Option to reply in threads

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -3,6 +3,11 @@ gpt_api_key: somestring
 model: gpt-3.5-turbo
 max_tokens: 2500
 
+# What sampling temperature to use, between 0 and 2.
+# Higher values like 0.8 will make the output more random,
+# while lower values like 0.2 will make it more focused and deterministic
+temperature: 1
+
 # allowed users who can make calls to the openAI APIs. an empty list
 # means everyone is allowed.
 allowed_users: []

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -1,7 +1,20 @@
 gpt_api_key: somestring
 
 model: gpt-3.5-turbo
-max_tokens: 2500
+
+# The maximum number of tokens to generate in the chat completion.
+# Leave blank to allow unlimited response length.
+# Note that is max_tokens + tokens in the input must be less than model's maximum context.
+max_tokens:
+
+# The maximum number of words allowed to in the input.
+# This includes the system prompt, additional context, and previous messages.
+# On average, there are 1.2 tokens per word.
+max_words: 1000
+
+# Maximum number of previous messages to include in input.
+# Usually max_words is reached before max_context_messages.
+max_context_messages: 20
 
 # What sampling temperature to use, between 0 and 2.
 # Higher values like 0.8 will make the output more random,
@@ -20,18 +33,21 @@ allowed_users: []
 # more than one user in them
 name: ''
 
+# Reply to queries in a thread and keep context within that thread.
+reply_in_thread: True
+
 # whether to enable multi-user awareness. this prefixes every context message
-# with the localpart of the sender of that message, and adds a system prompt
+# with the display name of the sender of that message, and adds a system prompt
 # informing the model of that fact. this increases personal data shared with
 # openAI as well as your used token count, but makes the bot work a little better
 # in multi-person chat rooms
 enable_multi_user: true
 
 # how to minimally train your bot. use this to adjust your bot's behavior.
-# you can use the {name} variable in this text.
+# you can use the {name} and {timestamp} variables in this text.
 system_prompt: |
     You are a friendly assistant named {name}. 
-    The currend datetime is {timestamp}, and this can be used reliably to 
+    The current datetime is {timestamp}, and this can be used reliably to 
     answer questions related to dates and times.
     Answer concisely.
 

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -36,6 +36,10 @@ name: ''
 # Reply to queries in a thread and keep context within that thread.
 reply_in_thread: True
 
+# Respond to replies to the bot's messages in addition to references the bot by name.
+# This should probably be disabled if the bot's account is running any other plugins.
+respond_to_replies: False
+
 # whether to enable multi-user awareness. this prefixes every context message
 # with the display name of the sender of that message, and adds a system prompt
 # informing the model of that fact. this increases personal data shared with

--- a/gpt.py
+++ b/gpt.py
@@ -150,7 +150,7 @@ class GPTPlugin(Plugin):
             content = response_json["choices"][0]["message"]["content"]
             # strip off extra colons which the model seems to keep adding no matter how
             # much you tell it not to
-            content = re.sub('^\w?\:+\s+', '', content)
+            content = re.sub('^\w*\:+\s+', '', content)
             #self.log.debug(content)
             return content
 

--- a/gpt.py
+++ b/gpt.py
@@ -27,6 +27,7 @@ class Config(BaseProxyConfig):
         helper.copy("name")
         helper.copy("allowed_users")
         helper.copy("addl_context")
+        helper.copy("temperature")
 
 class GPTPlugin(Plugin):
 
@@ -138,7 +139,8 @@ class GPTPlugin(Plugin):
         data = {
             "model": self.config['model'],
             "messages": full_context,
-            "max_tokens": self.config['max_tokens']
+            "max_tokens": self.config['max_tokens'],
+            "temperature": self.config['temperature'],
         }
         
         async with self.http.post(

--- a/gpt.py
+++ b/gpt.py
@@ -10,11 +10,10 @@ from collections import deque, defaultdict
 from maubot.handlers import command, event
 from maubot import Plugin, MessageEvent
 from mautrix.errors import MNotFound, MatrixRequestError
-from mautrix.types import TextMessageEventContent, EventType, RoomID, UserID, MessageType
+from mautrix.types import TextMessageEventContent, EventType, RoomID, UserID, MessageType, RelationType
 from mautrix.util.config import BaseProxyConfig, ConfigUpdateHelper
 
 GPT_API_URL = "https://api.openai.com/v1/chat/completions"
-EVENT_CACHE_LENGTH = 10
 
 
 class Config(BaseProxyConfig):
@@ -27,109 +26,76 @@ class Config(BaseProxyConfig):
         helper.copy("name")
         helper.copy("allowed_users")
         helper.copy("addl_context")
+        helper.copy("max_words")
+        helper.copy("max_context_messages")
+        helper.copy("reply_in_thread")
         helper.copy("temperature")
 
 class GPTPlugin(Plugin):
 
-    prev_room_events: Dict[RoomID, Deque[Dict]]
+    name: str # name of the bot
 
     async def start(self) -> None:
         await super().start()
         self.config.load_and_update()
-        self.name = self.config['name'] if self.config['name'] else self.client.parse_user_id(self.client.mxid)[0]
+        self.name = self.config['name'] or await self.client.get_displayname(self.client.mxid)
         self.log.debug(f"DEBUG gpt plugin started with bot name: {self.name}")
-        self.prev_room_events = defaultdict(lambda: deque(maxlen=EVENT_CACHE_LENGTH))
+
+
+    async def should_respond(self, event: MessageEvent) -> bool:
+        """ Determine if we should respond to an event """
+
+        if (event.sender == self.client.mxid or  # Ignore ourselves
+                event.content.body.startswith('!') or # Ignore commands
+                event.content['msgtype'] != MessageType.TEXT or  # Don't respond to media or notices
+                event.content.relates_to['rel_type'] == RelationType.REPLACE):  # Ignore edits
+            return False
+
+        if len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']:
+            await event.respond("sorry, you're not allowed to use this functionality.")
+            return False
+
+        # Check if the message contains the bot's ID
+        if re.search("(^|\s)(@)?" + self.name + "([ :,.!?]|$)", event.content.body, re.IGNORECASE):
+            return True
+
+        # Reply to all DMs
+        if len(await self.client.get_joined_members(event.room_id)) == 2:
+            return True
+
+        # Reply to threads if the thread's parent should be replied to
+        if self.config['reply_in_thread'] and event.content.relates_to.rel_type == RelationType.THREAD:
+            parent_event = await self.client.get_event(room_id=event.room_id, event_id=event.content.get_thread_parent())
+            return await self.should_respond(parent_event)
+
+        return False
+
 
     @event.on(EventType.ROOM_MESSAGE)
     async def on_message(self, event: MessageEvent) -> None:
-        role = ''
-        user = ''
-        content = ''
-        timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
 
-        if event.sender == self.client.mxid:
-            role = 'assistant'
-        else:
-            role = 'user'
-            if self.config['enable_multi_user']:
-                user = self.client.parse_user_id(event.sender)[0] + ': ' # only use the localpart
-
-        # keep track of all messages, even if the bot sent them
-        self.prev_room_events[event.room_id].append({"role": role , "content": 
-                                                     user + event['content']['body']})
-
-        # if the bot sent the message or another command was issued, just pass
-        if event.sender == self.client.mxid or event.content.body.startswith('!'):
+        if not await self.should_respond(event):
             return
 
-        joined_members = await self.client.get_joined_members(event.room_id)
-
         try:
-            # Check if the message contains the bot's ID
-            match_name = re.search("(^|\s)(@)?" + self.name + "([ :,.!?]|$)", event.content.body, re.IGNORECASE)
-            if match_name or len(joined_members) == 2:
-                if event.content.msgtype == MessageType.NOTICE:
-                    return # don't respond to other bot messages
+            context = await self.get_context(event)
+            await event.mark_read()
 
-                if len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']:
-                    await event.respond("sorry, you're not allowed to use this functionality.")
-                    return
+            # Call the chatGPT API to get a response
+            await self.client.set_typing(event.room_id, timeout=99999)
+            response = await self._call_gpt(context)
 
-                prompt = self.config['system_prompt'].format(name=self.name, timestamp=timestamp)
-                system_prompt = {"role": "system", "content": prompt}
-
-                await event.mark_read()
-                
-                context = self.prev_room_events.get(event.room_id, [])
-                # if our short history is already at max capacity, drop the oldest messages
-                # to make room for our more important system prompt(s)
-                addl_context = json.loads(json.dumps(self.config['addl_context']))
-                # full prompt count is number of messages provided in config, plus system prompt
-                prompt_count = len(addl_context) + 1
-
-                # too many prompts? that's a problem, just bomb out.
-                # we'll always want to save the last message in the cache because that's our prompt
-                if prompt_count > EVENT_CACHE_LENGTH - 1:
-                    await event.respond("sorry, my configuration has too many prompts and i'll never see your message.\
-                                        update my config to have fewer messages and i'll be able to answer your\
-                                        questions!")
-                    return
-
-                # find out how many spots we need to open up to prepend our prompts
-                if prompt_count >= EVENT_CACHE_LENGTH - len(context):
-                    for c in range(1, prompt_count):
-                        context.popleft()
-
-                for m in addl_context:
-                    context.appendleft(addl_context.pop())
-                context.appendleft(system_prompt)
-
-                #self.log.debug(f"CONTEXT: {context}")
-
-                # Call the chatGPT API to get a response
-                await self.client.set_typing(event.room_id, timeout=99999)
-                response = await self._call_gpt(context)
-                
-                # Send the response back to the chat room
-                await self.client.set_typing(event.room_id, timeout=0)
-                await event.respond(f"{response}")
+            # Send the response back to the chat room
+            await self.client.set_typing(event.room_id, timeout=0)
+            await event.respond(f"{response}", in_thread=self.config['reply_in_thread'])
         except Exception as e:
-            self.log.error(f"Something went wrong: {e}")
+            self.log.exception(f"Something went wrong: {e}")
+            await event.respond(f"Something went wrong: {e}")
             pass
 
     async def _call_gpt(self, prompt):
         full_context = []
-        if self.config['enable_multi_user']:
-            full_context.append({'role': 'system', 'content': 'user messages are in the context of\
-                    multiperson chatrooms. each message indicates its sender by prefixing\
-                    the message with the sender\'s name followed by a colon, such as this example:\
-                    \
-                    "username: hello world."\
-                    \
-                    in this case, the user called "username" sent the\
-                    message "hello world.". you should not follow this convention in your responses.\
-                    your response instead could be "hello username!" without including any colons,\
-                    because you are the only one sending your responses there is no need to prefix them.'})
+
 
         full_context.extend(list(prompt))
         headers = {
@@ -142,7 +108,9 @@ class GPTPlugin(Plugin):
             "max_tokens": self.config['max_tokens'],
             "temperature": self.config['temperature'],
         }
-        
+
+        self.log.debug("CONTEXT:\n" + "\n".join([f'{m["role"]}: {m["content"]}' for m in full_context]))
+
         async with self.http.post(
             GPT_API_URL, headers=headers, data=json.dumps(data)
         ) as response:
@@ -150,21 +118,74 @@ class GPTPlugin(Plugin):
                 return f"Error: {await response.text()}"
             response_json = await response.json()
             content = response_json["choices"][0]["message"]["content"]
+            self.log.debug(f'GPT tokens used: {response_json["usage"]}')
             # strip off extra colons which the model seems to keep adding no matter how
             # much you tell it not to
             content = re.sub('^\w*\:+\s+', '', content)
-            #self.log.debug(content)
             return content
 
     @command.new(name='gpt', help='control chatGPT functionality', require_subcommand=True)
     async def gpt(self, evt: MessageEvent) -> None:
         pass
 
-    @gpt.subcommand("clear", help="clear the cache of context and return the bot to its original system prompt")
-    async def clear_cache(self, evt: MessageEvent) -> None:
-        self.prev_room_events.pop(evt.room_id)
-        await evt.react('✅')
 
+    async def get_context(self, event: MessageEvent):
+
+        system_context = deque()
+        timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        system_prompt = {"role": "system",
+                         "content": self.config['system_prompt'].format(name=self.name, timestamp=timestamp)}
+        if self.config['enable_multi_user']:
+            system_prompt["content"] += """
+User messages are in the context of multiperson chatrooms.
+Each message indicates its sender by prefixing the message with the sender's name followed by a colon, for example:
+"username: hello world."
+In this case, the user called "username" sent the message "hello world.". You should not follow this convention in your responses.
+your response instead could be "hello username!" without including any colons, because you are the only one sending your responses there is no need to prefix them.
+"""
+        system_context.append(system_prompt)
+
+        addl_context = json.loads(json.dumps(self.config['addl_context']))
+        if addl_context:
+            for item in addl_context:
+                system_context.append(item)
+            if len(addl_context) > self.config["max_context_messages"] - 1:
+                raise ValueError(f"sorry, my configuration has too many additional prompts "
+                                 f"({self.config['max_context_messages']}) and i'll never see your message. "
+                                    f"Update my config to have fewer messages and i'll be able to answer your questions!")
+
+
+        chat_context = deque()
+        word_count = sum([len(m["content"].split()) for m in system_context])
+        message_count = len(system_context) - 1
+        async for next_event in self.generate_context_messages(event):
+
+            role = 'assistant' if next_event.sender == self.client.mxid else 'user'
+            message = next_event['content']['body']
+            user = ''
+            if self.config['enable_multi_user']:
+                user = (await self.client.get_displayname(next_event.sender)) + ": "
+
+            word_count += len(message.split())
+            message_count += 1
+            if word_count >= self.config['max_words'] or message_count >= self.config['max_context_messages']:
+                break
+
+            chat_context.appendleft({"role": role, "content": user + message})
+
+        return system_context + chat_context
+
+    async def generate_context_messages(self, evt: MessageEvent):
+        yield evt
+        if self.config['reply_in_thread']:
+            while evt.content.relates_to.in_reply_to:
+                evt = await self.client.get_event(room_id=evt.room_id, event_id=evt.content.get_reply_to())
+                yield evt
+        else:
+            event_context = await self.client.get_event_context(room_id=evt.room_id, event_id=evt.event_id, limit=self.config["max_context_messages"]*2)
+            previous_messages = iter(event_context.events_before)
+            for evt in previous_messages:
+                yield evt
 
     @classmethod
     def get_config_class(cls) -> Type[BaseProxyConfig]:

--- a/gpt.py
+++ b/gpt.py
@@ -30,6 +30,7 @@ class Config(BaseProxyConfig):
         helper.copy("max_context_messages")
         helper.copy("reply_in_thread")
         helper.copy("temperature")
+        helper.copy("respond_to_replies")
 
 class GPTPlugin(Plugin):
 
@@ -67,6 +68,12 @@ class GPTPlugin(Plugin):
         if self.config['reply_in_thread'] and event.content.relates_to.rel_type == RelationType.THREAD:
             parent_event = await self.client.get_event(room_id=event.room_id, event_id=event.content.get_thread_parent())
             return await self.should_respond(parent_event)
+
+        # Reply to messages replying to the bot
+        if self.config['respond_to_replies'] and event.content.relates_to.in_reply_to:
+            parent_event = await self.client.get_event(room_id=event.room_id, event_id=event.content.get_reply_to())
+            if parent_event.sender == self.client.mxid:
+                return True
 
         return False
 


### PR DESCRIPTION
[matrix-chatgpt-bot](https://github.com/matrixgpt/matrix-chatgpt-bot) has a pretty nice feature to reply to messages in threads and keep a conversations' context within the thread, so I added that feature to this plugin.

As part of that modification, I also made this plugin stateless by calling `get_event_context` instead of caching messages.

I also added a word limit parameter because openai's API responds with an error if `max_token` + input tokens is larger than the model's limit even if the actual number of tokens the model would return is low, so limiting tokens by limiting the number of input words seems to work more reliably for me at least.