### PR TITLE
Fix errors with deleted messages and new rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # chatGPT 
 
-maubot plugin to allow your maubot instance to return queries from openAI GPT API endpoints. 
+maubot plugin to allow your maubot instance to return queries from openAI GPT API endpoints.
 
-add your openAI API key to the config, and modify as you see fit. if you don't know what the options are, you
-probably shouldn't be using this. please refer to the openai documentation.
+## Usage
 
-be warned, this plugin keeps a cache of the last 10 messages it has seen across all rooms, and submits the ones most
-recently sent in the current room to provide additional context to the conversational API endpoint. this means you can
-have reasonable success with contextual follow-up questions, but may be seen as a significant security leak for
-private rooms, and you may be using significantly more tokens than you think with each request. use this bot responsibly.
+1. Create the bot instance in Maubot Manager, add your openAI API key to the config, and modify as you see fit.
+2. Invite the bot to a room.
+3. Ping the bot by mentioning it by name.
 
+## Features
+
+See `base-config.yaml` for more details.
+
+* Uses the most recent messages in the room for context, or replies to queries in threads to keep conversations isolated
+* Multi-user awareness:
+  * Option to prefix every context message with the display name of the sender, and adds a system prompt informing the model of that fact. this increases personal data shared with openAI as well as your used token count, but makes the bot work a little better in multi-person chat rooms
+* Configurable system prompt and option to pre-append messages to the context

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -36,10 +36,6 @@ name: ''
 # Reply to queries in a thread and keep context within that thread.
 reply_in_thread: True
 
-# Respond to replies to the bot's messages in addition to references the bot by name.
-# This should probably be disabled if the bot's account is running any other plugins.
-respond_to_replies: False
-
 # whether to enable multi-user awareness. this prefixes every context message
 # with the display name of the sender of that message, and adds a system prompt
 # informing the model of that fact. this increases personal data shared with

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -56,7 +56,7 @@ system_prompt: |
     Answer concisely.
 
 # additional context to provide in the prompts.
-# keep in mind the max number of context messages is 10 across all rooms,
+# keep in mind this counts towards max_context_messages,
 # so leave room here to include previous questions and context.
 # refer to documentation about zero-shot, one-shot, and few-shot prompts.
 # leave this an empty list to skip it altogether.


### PR DESCRIPTION
Closes #6 

Fixes bug by ignoring any events that don't have both a `content` and  `content.msgtype` attribute.

Unrelated but I also added a commit that adds a "org.jobmachine.chatgpt" key to the message data, so that the bot can respond to replies without affecting other bots running on the same account. It seemed simpler than having an option in the config, but I can undo that if it's a bad idea (or move it back to the config)