### PR TITLE
Stop spamming rooms with unauthorized messages

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -55,13 +55,13 @@ class GPTPlugin(Plugin):
                 event.content.relates_to['rel_type'] == RelationType.REPLACE):  # Ignore edits
             return False
 
-        if len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']:
-            await event.respond("sorry, you're not allowed to use this functionality.")
-            return False
-
         # Check if the message contains the bot's ID
         if re.search("(^|\s)(@)?" + self.name + "([ :,.!?]|$)", event.content.body, re.IGNORECASE):
-            return True
+            if len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']:
+                await event.respond("sorry, you're not allowed to use this functionality.")
+                return False
+            else:
+                return True
 
         # Reply to all DMs
         if len(await self.client.get_joined_members(event.room_id)) == 2:


### PR DESCRIPTION
The `should_respond` function was repeatedly triggering an "user unauthorized" message from the bot, even when it was not called to way in on the conversation at all.

Nested `if`s are ugly, but this is perhaps the most straightforward (and easiest to reason about) solution.