### PR TITLE
Allow system wide usage for specific homeservers

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -28,6 +28,10 @@ temperature: 1
 # means everyone is allowed.
 allowed_users: []
 
+# allowed homeservers from where all users can make calls to the openAI APIs. 
+# an empty list means everyone is allowed.
+allowed_homeservers: []
+
 # your bot's name, for reference. leave blank to use mxid localpart
 # set this to a specific value if the bot's mxid localpart does not
 # match their display nick, as clients tend to use the display nick in

--- a/gpt.py
+++ b/gpt.py
@@ -24,6 +24,7 @@ class Config(BaseProxyConfig):
         helper.copy("system_prompt")
         helper.copy("name")
         helper.copy("allowed_users")
+        helper.copy("allowed_homeservers")
         helper.copy("addl_context")
         helper.copy("max_words")
         helper.copy("max_context_messages")
@@ -55,7 +56,9 @@ class GPTPlugin(Plugin):
                 event.content.relates_to['rel_type'] == RelationType.REPLACE):  # Ignore edits
             return False
 
-        if len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']:
+        if ((len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']) or
+                (len(self.config['allowed_homeservers']) > 0 
+                and re.sub("^@.*:", "", event.sender) not in self.config['allowed_homeservers'])):
             await event.respond("sorry, you're not allowed to use this functionality.")
             return False
 


### PR DESCRIPTION
Introduce a new config variable `allowed_homeservers` to enable usage of chatgpt for all users of a specific homeserver.