### PR TITLE
Allow regexes in 'allowed_users'

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -24,8 +24,9 @@ max_context_messages: 20
 # while lower values like 0.2 will make it more focused and deterministic
 temperature: 1
 
-# allowed users who can make calls to the openAI APIs. an empty list
-# means everyone is allowed.
+# list of allowed users who can make calls to the openAI APIs. an empty list
+# means everyone is allowed. you can use a regex to allow all users of a 
+# homeserver ('^@.*:homeserverdomain.tld$')
 allowed_users: []
 
 # your bot's name, for reference. leave blank to use mxid localpart

--- a/gpt.py
+++ b/gpt.py
@@ -55,9 +55,11 @@ class GPTPlugin(Plugin):
                 event.content.relates_to['rel_type'] == RelationType.REPLACE):  # Ignore edits
             return False
 
-        if len(self.config['allowed_users']) > 0 and event.sender not in self.config['allowed_users']:
-            await event.respond("sorry, you're not allowed to use this functionality.")
-            return False
+        if len(self.config['allowed_users']) > 0:
+            allowed_regexes = "(" + ")|(".join(self.config['allowed_users']) + ")"
+            if not re.match(allowed_regexes, event.sender):
+                await event.respond("sorry, you're not allowed to use this functionality.")
+                return False
 
         # Check if the message contains the bot's ID
         if re.search("(^|\s)(@)?" + self.name + "([ :,.!?]|$)", event.content.body, re.IGNORECASE):


### PR DESCRIPTION
Allow to specify regexes in `allowed_users` list. This makes it possible to enable chatgpt for all users of a specific homeserver. Superseeds https://github.com/williamkray/maubot-chatgpt/pull/12